### PR TITLE
Modified  project to ensure proper pch usage

### DIFF
--- a/src/input/mapper.cpp
+++ b/src/input/mapper.cpp
@@ -1,6 +1,5 @@
+#include "pch.hpp"
 #include "input/mapper.hpp"
-
-#include <exception>
 
 namespace rp::input {
       InputMapper::MappingID InputMapper::mapKeyPressEvent(const std::string& mapName, Keyboard::Key key, InputMapper::Callback keyCallback) {

--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -14,5 +14,11 @@
 #include <fmt/format.h>
 #include <fmt/color.h>
 
+//Windows headers
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#include <windowsx.h>
+
 //common internal headers
 #include "log/log_internal.hpp"

--- a/src/platform/win32_keyboard.cpp
+++ b/src/platform/win32_keyboard.cpp
@@ -1,6 +1,5 @@
+#include "pch.hpp"
 #include "platform/win32_keyboard.hpp"
-
-#include "log/log_internal.hpp"
 
 namespace rp::input {
   Keyboard::Key translateWin32KeyCode(WPARAM win32_key_code, LPARAM flags) {

--- a/src/platform/win32_keyboard.hpp
+++ b/src/platform/win32_keyboard.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-#include <windows.h>
+//include windows type definitions
+#include <WinDef.h>
 
 #include "input/keyboard.hpp"
 

--- a/src/platform/win32_window.cpp
+++ b/src/platform/win32_window.cpp
@@ -1,11 +1,10 @@
 #include "pch.hpp"
-
 #include "platform/win32_window.hpp"
-#include "platform/win32_keyboard.hpp"
 
 #include "input/keyboard.hpp"
 #include "input/mouse.hpp"
 
+#include "platform/win32_keyboard.hpp"
 namespace rp {
 
   Win32Window::Win32Window(const Properties& props) : Window(props) {

--- a/src/platform/win32_window.hpp
+++ b/src/platform/win32_window.hpp
@@ -2,10 +2,8 @@
 
 #include "core/window.hpp"
 
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-#include <windows.h>
-#include <windowsx.h>
+//include windows type definitions
+#include <winDef.h>
 
 namespace rp {
   class Win32Window : public rp::Window {

--- a/src/util/uuid.cpp
+++ b/src/util/uuid.cpp
@@ -1,5 +1,5 @@
-#include "util/uuid.hpp"
 #include "pch.hpp"
+#include "util/uuid.hpp"
 
 namespace rp {
   constexpr std::array<uint8_t, 16> nil_uuid_data = {

--- a/src/util/version.cpp
+++ b/src/util/version.cpp
@@ -1,5 +1,4 @@
 #include "pch.hpp"
-
 #include "util/version.hpp"
 
 namespace rp {


### PR DESCRIPTION
- STL headers changed from direct inclusion to inclusion in pch.hpp
- Ensured all *.cpp include "pch.hpp" as first line
- Added windows include + #defines to pch.h
- Replaced windows includes in header files with WinDef.h includes, much more lightweight